### PR TITLE
add d.ts file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,3 @@
+declare const plugin: { handler: () => void };
+
+export = plugin;


### PR DESCRIPTION
Hello!

Now that tailwind configs can be written in TypeScript ([docs](https://tailwindcss.com/docs/configuration#using-esm-or-type-script)), it would be great to include a `d.ts` file with this plugin so that users don't need to declare types themselves.

The `d.ts` file I'm proposing is [the same as the one used in the official tailwindcss-line-clamp plugin](https://github.com/tailwindlabs/tailwindcss-line-clamp/blob/master/src/index.d.ts).  I've also tested it on my own project and it works.